### PR TITLE
Fix Scheduler Process Crash

### DIFF
--- a/hueyx/consumer.py
+++ b/hueyx/consumer.py
@@ -16,7 +16,7 @@ class HueyxScheduler(Scheduler):
     This is done by locking the specific execution time pattern on redis.
     """
 
-    def enqueue_periodic_tasks(self, now, start):
+    def enqueue_periodic_tasks(self, now):
         self._logger.debug('Checking periodic tasks')
         if now is None:
             now = datetime.datetime.now()


### PR DESCRIPTION
Removed an extra argument that was being passed to enqueue_periodic_task()

Fixes TypeError: enqueue_periodic_tasks() missing 1 required positional argument: 'start' 
In huey/consumer.py line 171 - self.enqueue_periodic_tasks(now)